### PR TITLE
Fix Java example app TerminalFragment

### DIFF
--- a/Example/build.gradle
+++ b/Example/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Example/javaapp/src/main/java/com/stripe/example/javaapp/fragment/TerminalFragment.java
+++ b/Example/javaapp/src/main/java/com/stripe/example/javaapp/fragment/TerminalFragment.java
@@ -3,14 +3,18 @@ package com.stripe.example.javaapp.fragment;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
 import com.stripe.example.javaapp.NavigationListener;
 import com.stripe.example.javaapp.R;
+import com.stripe.example.javaapp.databinding.FragmentTerminalBinding;
 import com.stripe.example.javaapp.viewmodel.TerminalViewModel;
 
 import org.jetbrains.annotations.NotNull;
@@ -47,6 +51,19 @@ public class TerminalFragment extends Fragment {
             }
             viewModel = new TerminalViewModel(isSimulated);
         }
+    }
+
+    @Override
+    public @Nullable View onCreateView(
+            @NotNull LayoutInflater inflater,
+            @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState
+    ) {
+        // Inflate the layout for this fragment
+        final FragmentTerminalBinding binding = DataBindingUtil.inflate(inflater, R.layout.fragment_terminal, container, false);
+        binding.setLifecycleOwner(this);
+        binding.setViewModel(viewModel);
+        return binding.getRoot();
     }
 
     @Override

--- a/Example/javaapp/src/main/res/layout/fragment_terminal.xml
+++ b/Example/javaapp/src/main/res/layout/fragment_terminal.xml
@@ -3,6 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+        <variable
+            name="viewModel"
+            type="com.stripe.example.javaapp.viewmodel.TerminalViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
The databinding in TerminalFragment on the Java app was broken, leading
to an empty screen being shown, as documented in issue
[103](https://github.com/stripe/stripe-terminal-android/issues/103).

This patch fixes that issue.