### PR TITLE
Bump stripeterminal dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In order to use the Android version of the Terminal SDK, you first have to add t
 
 
     dependencies {
-      implementation "com.stripe:stripeterminal:1.0.1"
+      implementation "com.stripe:stripeterminal:1.0.17"
     }
     
 Next, since the SDK relies on Java 8, you’ll need to specify that as your target Java version (also in `build.gradle`:


### PR DESCRIPTION
I believe we must have forgotten to bump the README on the last release.