### PR TITLE
Use buildFeatures formatting

### DIFF
--- a/Example/javaapp/build.gradle
+++ b/Example/javaapp/build.gradle
@@ -8,8 +8,8 @@ android {
         targetSdkVersion maxSdkVersion
     }
 
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding true
     }
 
     compileOptions {

--- a/Example/kotlinapp/build.gradle
+++ b/Example/kotlinapp/build.gradle
@@ -15,8 +15,8 @@ android {
         targetSdkVersion maxSdkVersion
     }
 
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding true
     }
 
     compileOptions {


### PR DESCRIPTION
Seeing a warning on a command line build and it references:

https://developer.android.com/studio/releases/gradle-plugin#buildFeatures
```
st-sgaw1:Example sgaw$ ./gradlew installDebug

> Configure project :javaapp
WARNING: DSL element 'android.dataBinding.enabled' is obsolete and has been replaced with 'android.buildFeatures.dataBinding'.
It will be removed in version 5.0 of the Android Gradle plugin.

> Configure project :kotlinapp
WARNING: DSL element 'android.dataBinding.enabled' is obsolete and has been replaced with 'android.buildFeatures.dataBinding'.
It will be removed in version 5.0 of the Android Gradle plugin.

```