### PR TITLE
Use alert boxes instead of a runtime exception 

### DIFF
--- a/Example/javaapp/src/main/java/com/stripe/example/javaapp/MainActivity.java
+++ b/Example/javaapp/src/main/java/com/stripe/example/javaapp/MainActivity.java
@@ -47,9 +47,12 @@ public class MainActivity extends AppCompatActivity implements NavigationListene
 
         // Check that the example app has been configured correctly
         if (ApiClient.BACKEND_URL.isEmpty()) {
-            throw new RuntimeException(
-                    "You need to set the BACKEND_URL constant in ApiClient.java " +
-                    "before you'll be able to use the example app.");
+            new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_DarkActionBar))
+                    .setMessage("You need to set the BACKEND_URL constant in ApiClient.java before you'll be able to use the " +
+                            "example app.")
+                    .setCancelable(false)
+                    .create()
+                    .show();
         }
 
         if (BluetoothAdapter.getDefaultAdapter() != null &&

--- a/Example/javaapp/src/main/java/com/stripe/example/javaapp/MainActivity.java
+++ b/Example/javaapp/src/main/java/com/stripe/example/javaapp/MainActivity.java
@@ -17,6 +17,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.stripe.example.javaapp.fragment.ConnectedReaderFragment;
 import com.stripe.example.javaapp.fragment.PaymentFragment;
 import com.stripe.example.javaapp.fragment.TerminalFragment;
@@ -47,9 +48,8 @@ public class MainActivity extends AppCompatActivity implements NavigationListene
 
         // Check that the example app has been configured correctly
         if (ApiClient.BACKEND_URL.isEmpty()) {
-            new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_DarkActionBar))
-                    .setMessage("You need to set the BACKEND_URL constant in ApiClient.java before you'll be able to use the " +
-                            "example app.")
+            new MaterialAlertDialogBuilder(this)
+                    .setMessage(R.string.update_background_url)
                     .setCancelable(false)
                     .create()
                     .show();
@@ -228,12 +228,11 @@ public class MainActivity extends AppCompatActivity implements NavigationListene
 
         if (!gpsEnabled) {
             // notify user
-            new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_DarkActionBar))
-                    .setMessage("Please enable location services")
+            new MaterialAlertDialogBuilder(this, R.style.Widget_Example_MaterialComponents_MaterialAlertDialog)
+                    .setMessage(R.string.enabled_location_services)
                     .setCancelable(false)
-                    .setPositiveButton("Open location settings", (dialog, which) -> {
-                        startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS));
-                    })
+                    .setPositiveButton(R.string.open_location_settings, ((dialog, which) ->
+                            startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))))
                     .create()
                     .show();
         }

--- a/Example/javaapp/src/main/res/values/strings.xml
+++ b/Example/javaapp/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="discover_readers">Discover Readers</string>
     <string name="done">Done</string>
     <string name="empty_reader">Empty Reader</string>
+    <string name="enabled_location_services">Please enable location services</string>
     <string name="event_log">EVENT LOG</string>
     <string name="install_explanation">Version %1$s available. The reader will become unresponsive until the update is complete. Estimated update time: %2$s.</string>
     <string name="install_update">Install update</string>
@@ -27,6 +28,7 @@
     <string name="nearby_readers">NEARBY READERS</string>
     <string name="no_reader">No reader connected</string>
     <string name="no_update_available">No update available</string>
+    <string name="open_location_settings">Open location settings</string>
     <string name="read_card_for_recurring_payment">Read card for recurring payment</string>
     <string name="reader">Reader</string>
     <string name="reader_connection">READER CONNECTION</string>
@@ -35,6 +37,7 @@
     <string name="simulation_explanation">The SDK comes with the ability to simulate behavior without using physical hardware. This makes it easy to quickly test your integration end-to-end, from connecting a reader to taking payments.</string>
     <string name="terminal">Terminal</string>
     <string name="testing">Testing</string>
+    <string name="update_background_url">You need to set the BACKEND_URL constant in ApiClient.java before you\'ll be able to use the example app.</string>
     <string name="update_complete">Update complete</string>
     <string name="update_explanation">Check if a reader software update is available.</string>
     <string name="update_in_progress">Update in progress</string>

--- a/Example/javaapp/src/main/res/values/styles.xml
+++ b/Example/javaapp/src/main/res/values/styles.xml
@@ -43,6 +43,16 @@
         <item name="android:textAllCaps">false</item>
     </style>
 
+    <style name="Widget.Example.MaterialComponents.MaterialAlertDialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.Example.MaterialComponents.Button.TextButton.Dialog</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.Example.MaterialComponents.Button.TextButton.Dialog</item>
+    </style>
+
+    <style name="Widget.Example.MaterialComponents.Button.TextButton.Dialog" parent="@style/Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/colorAccent</item>
+        <item name="backgroundTint">@color/colorPrimary</item>
+    </style>
+
     <style name="Widget.Example.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
         <item name="android:paddingTop">4dp</item>
         <item name="boxBackgroundColor">?attr/colorPrimaryDark</item>

--- a/Example/kotlinapp/src/main/java/com/stripe/example/MainActivity.kt
+++ b/Example/kotlinapp/src/main/java/com/stripe/example/MainActivity.kt
@@ -44,9 +44,13 @@ class MainActivity : AppCompatActivity(), NavigationListener {
 
         // Check that the example app has been configured correctly
         if (ApiClient.BACKEND_URL.isEmpty()) {
-            throw RuntimeException("You need to set the BACKEND_URL constant in ApiClient.kt " +
-                    "before you'll be able to use the example app.")
-        }
+            // notify user
+            AlertDialog.Builder(ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_DarkActionBar))
+                    .setMessage("You need to set the BACKEND_URL constant in ApiClient.kt " +
+                            "before you'll be able to use the example app.")
+                    .setCancelable(false)
+                    .create()
+                    .show() }
 
         if (BluetoothAdapter.getDefaultAdapter()?.isEnabled == false) {
             BluetoothAdapter.getDefaultAdapter().enable()

--- a/Example/kotlinapp/src/main/java/com/stripe/example/MainActivity.kt
+++ b/Example/kotlinapp/src/main/java/com/stripe/example/MainActivity.kt
@@ -8,12 +8,12 @@ import android.content.pm.PackageManager
 import android.location.LocationManager
 import android.os.Bundle
 import android.provider.Settings
-import android.view.ContextThemeWrapper
-import androidx.appcompat.app.AlertDialog
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.stripe.example.fragment.ConnectedReaderFragment
 import com.stripe.example.fragment.PaymentFragment
 import com.stripe.example.fragment.TerminalFragment
@@ -45,12 +45,12 @@ class MainActivity : AppCompatActivity(), NavigationListener {
         // Check that the example app has been configured correctly
         if (ApiClient.BACKEND_URL.isEmpty()) {
             // notify user
-            AlertDialog.Builder(ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_DarkActionBar))
-                    .setMessage("You need to set the BACKEND_URL constant in ApiClient.kt " +
-                            "before you'll be able to use the example app.")
+            MaterialAlertDialogBuilder(this)
+                    .setMessage(R.string.update_background_url)
                     .setCancelable(false)
                     .create()
-                    .show() }
+                    .show()
+        }
 
         if (BluetoothAdapter.getDefaultAdapter()?.isEnabled == false) {
             BluetoothAdapter.getDefaultAdapter().enable()
@@ -205,10 +205,9 @@ class MainActivity : AppCompatActivity(), NavigationListener {
 
         if (!gpsEnabled) {
             // notify user
-            AlertDialog.Builder(ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_DarkActionBar))
-                    .setMessage("Please enable location services")
-                    .setCancelable(false)
-                    .setPositiveButton("Open location settings") { param, paramInt ->
+            MaterialAlertDialogBuilder(this, R.style.Widget_Example_MaterialComponents_MaterialAlertDialog)
+                    .setMessage(R.string.enabled_location_services)
+                    .setPositiveButton(R.string.open_location_settings) { _, _ ->
                         this.startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
                     }
                     .create()

--- a/Example/kotlinapp/src/main/res/values/strings.xml
+++ b/Example/kotlinapp/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="discover_readers">Discover Readers</string>
     <string name="done">Done</string>
     <string name="empty_reader">Empty Reader</string>
+    <string name="enabled_location_services">Please enable location services</string>
     <string name="event_log">EVENT LOG</string>
     <string name="install_explanation">Version %1$s available. The reader will become unresponsive until the update is complete. Estimated update time: %2$s.</string>
     <string name="install_update">Install update</string>
@@ -27,6 +28,7 @@
     <string name="nearby_readers">NEARBY READERS</string>
     <string name="no_reader">No reader connected</string>
     <string name="no_update_available">No update available</string>
+    <string name="open_location_settings">Open location settings</string>
     <string name="read_card_for_recurring_payment">Read card for recurring payment</string>
     <string name="reader">Reader</string>
     <string name="reader_connection">READER CONNECTION</string>
@@ -35,6 +37,7 @@
     <string name="simulation_explanation">The SDK comes with the ability to simulate behavior without using physical hardware. This makes it easy to quickly test your integration end-to-end, from connecting a reader to taking payments.</string>
     <string name="terminal">Terminal</string>
     <string name="testing">Testing</string>
+    <string name="update_background_url">You need to set the BACKEND_URL constant in ApiClient.kt before you\'ll be able to use the example app."</string>
     <string name="update_complete">Update complete</string>
     <string name="update_explanation">Check if a reader software update is available.</string>
     <string name="update_in_progress">Update in progress</string>

--- a/Example/kotlinapp/src/main/res/values/styles.xml
+++ b/Example/kotlinapp/src/main/res/values/styles.xml
@@ -43,6 +43,16 @@
         <item name="android:textAllCaps">false</item>
     </style>
 
+    <style name="Widget.Example.MaterialComponents.MaterialAlertDialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="buttonBarPositiveButtonStyle">@style/Widget.Example.MaterialComponents.Button.TextButton.Dialog</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Widget.Example.MaterialComponents.Button.TextButton.Dialog</item>
+    </style>
+
+    <style name="Widget.Example.MaterialComponents.Button.TextButton.Dialog" parent="@style/Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/colorAccent</item>
+        <item name="backgroundTint">@color/colorPrimary</item>
+    </style>
+
     <style name="Widget.Example.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
         <item name="android:paddingTop">4dp</item>
         <item name="boxBackgroundColor">?attr/colorPrimaryDark</item>


### PR DESCRIPTION
Currently the first launch of the app crashes if if the BACKGROUND_URL has been left in it's default state (empty).  Instead of a RuntimeException which has to be checked in logcat, just show an alert.

|Screen| Java | Kotlin|
|---|---|---|
|Empty BACKGROUND_URL |![Screenshot_1613693805](https://user-images.githubusercontent.com/79179505/108441675-7dc16d80-720a-11eb-81e8-ea3e0be620f4.png)| ![Screenshot_1613693291](https://user-images.githubusercontent.com/79179505/108441695-87e36c00-720a-11eb-9dbf-356c2aea4e02.png)|
| Disabled location | ![Screenshot_1613695854](https://user-images.githubusercontent.com/79179505/108441717-96318800-720a-11eb-86d8-08bf483874bd.png)|![Screenshot_1613696069](https://user-images.githubusercontent.com/79179505/108441736-a0538680-720a-11eb-937c-c554d67cd4c8.png)|

- Extract dialog text into string resource.
- Overrides default button themes for MaterialAlertDialog because otherwise it's white text on a white background.
