### PR TITLE
Remove StrictMode.penaltyDeath() to prevent crash for Android < 12 devices

### DIFF
--- a/Example/javaapp/src/main/java/com/stripe/example/javaapp/StripeTerminalApplication.java
+++ b/Example/javaapp/src/main/java/com/stripe/example/javaapp/StripeTerminalApplication.java
@@ -22,7 +22,6 @@ public class StripeTerminalApplication extends Application {
                         .detectLeakedSqlLiteObjects()
                         .detectLeakedClosableObjects()
                         .penaltyLog()
-                        .penaltyDeath()
                         .build());
 
         super.onCreate();

--- a/Example/kotlinapp/src/main/java/com/stripe/example/StripeTerminalApplication.kt
+++ b/Example/kotlinapp/src/main/java/com/stripe/example/StripeTerminalApplication.kt
@@ -21,7 +21,6 @@ class StripeTerminalApplication : Application() {
                 .detectLeakedSqlLiteObjects()
                 .detectLeakedClosableObjects()
                 .penaltyLog()
-                .penaltyDeath()
                 .build()
         )
 


### PR DESCRIPTION
User-facing example apps violate strict mode due to disk read from MainActivity.onCreate on Android devices less than Android 12