### PR TITLE
fix: removing extra " in EXAMPLE_BACKEND_URL(javaapp)

### DIFF
--- a/Example/javaapp/build.gradle
+++ b/Example/javaapp/build.gradle
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion maxSdkVersion
-        buildConfigField "String", "EXAMPLE_BACKEND_URL", "\"${project.getProperty("EXAMPLE_BACKEND_URL")}\""
+        buildConfigField "String", "EXAMPLE_BACKEND_URL", "${project.getProperty("EXAMPLE_BACKEND_URL")}"
     }
 
     buildFeatures {


### PR DESCRIPTION
\\" causing javaapp build to fail. 

BuildConfig.java
```
error: ';' expected
public static final String EXAMPLE_BACKEND_URL = ""https://stripe-backend.com/"";
```