### PR TITLE
[Docs] Add callout to not use localhost

### DIFF
--- a/Example/gradle.properties
+++ b/Example/gradle.properties
@@ -26,5 +26,9 @@ android.suppressUnsupportedCompileSdk=34
 # https://github.com/stripe/example-terminal-backend
 #
 # After deploying your backend, replace "" on the line below with the URL of your backend app.
+# NOTE: When using an Android emulator with a backend running on your host machine:
+# - DO NOT use "http://localhost:PORT" (this points to the emulator's own localhost)
+# - INSTEAD use "http://10.0.2.2:PORT" (this special IP allows the emulator to access your host machine)
+# Example: EXAMPLE_BACKEND_URL="http://10.0.2.2:4567"
 #
 # EXAMPLE_BACKEND_URL=""


### PR DESCRIPTION
`localhost` refers to the Android emulator's `localhost`, which can cause confusion