### PR TITLE
ci: restrict GITHUB_TOKEN permissions on Jira sync workflow

### DIFF
--- a/.github/workflows/github-jira-sync.yaml
+++ b/.github/workflows/github-jira-sync.yaml
@@ -1,6 +1,9 @@
 name: Sync GitHub issues to Jira
 on: [issues, issue_comment]
 
+permissions:
+  contents: read
+
 jobs:
   sync-issues:
     name: Sync issues to Jira


### PR DESCRIPTION
Declares `permissions: contents: read` on the Jira sync workflow. The workflow only forwards issue events to a Jira webhook and does not need write access to repository contents or other API scopes. Pinning the token to read-only limits exposure.

Reference: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication